### PR TITLE
Better .jshintrc config file discovery

### DIFF
--- a/Commands/JSHint and save.tmCommand
+++ b/Commands/JSHint and save.tmCommand
@@ -6,31 +6,27 @@
 	<string>saveActiveFile</string>
 	<key>command</key>
 	<string>#!/usr/bin/env bash
-[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+	[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
-if [[ -e "$TM_DIRECTORY/.jshintrc" ]]
-   then JSHINT_CONFIG="$TM_DIRECTORY/.jshintrc"
-fi
+	# Command to execute to find config file
+	CONFIG_FINDER="${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh"
 
-if [[ -e "$HOME/.jshintrc" ]]
-   then JSHINT_CONFIG="$HOME/.jshintrc"
-fi
+	# Name of the configuration file
+	JSHINT_RCFILE=".jshintrc"
 
-if [[ -e "$TM_PROJECT_DIRECTORY/.jshintrc" ]]
-   then JSHINT_CONFIG="$TM_PROJECT_DIRECTORY/.jshintrc"
-fi
+	# Get path to jshintrc file
+	JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
+	if [[ ! -e "${JSHINT_CONFIG}" ]]
+	   then 
+	   JSHINT_CONFIG=${TM_JSHINT_CONFIG}
+	fi
+	
+	# Run linter and show minimal output in a tool tip summary
+	cd "${TM_BUNDLE_SUPPORT}/reporter/"
+	node index.js --reporter textmate-tooltip-reporter.js --config "${JSHINT_CONFIG}" "${TM_FILEPATH}"
 
-if [[ -e $TM_JSHINT_CONFIG ]]
-   then JSHINT_CONFIG=$TM_JSHINT_CONFIG
-fi
-
-# run nodelint on the current file and output as a tool tip summary
-cd "${TM_BUNDLE_SUPPORT}/reporter/"
-
-node index.js --reporter textmate-tooltip-reporter.js --config "${JSHINT_CONFIG}" "${TM_FILEPATH}"
-
-exit 0
-</string>
+	exit 0
+	</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Commands/JSHint and save.tmCommand
+++ b/Commands/JSHint and save.tmCommand
@@ -14,11 +14,12 @@
 	# Name of the configuration file
 	JSHINT_RCFILE=".jshintrc"
 
-	# Get path to jshintrc file
-	JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
-	if [[ ! -e "${JSHINT_CONFIG}" ]]
-	   then 
-	   JSHINT_CONFIG=${TM_JSHINT_CONFIG}
+	# Get path to jshintrc file if TM_JSHINT_CONFIG is not specified
+	if [[ -e "${TM_JSHINT_CONFIG}" ]]
+	then 
+		JSHINT_CONFIG=${TM_JSHINT_CONFIG}
+	else
+		JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
 	fi
 	
 	# Run linter and show minimal output in a tool tip summary

--- a/Commands/JSHint.tmCommand
+++ b/Commands/JSHint.tmCommand
@@ -14,11 +14,12 @@
 	# Name of the configuration file
 	JSHINT_RCFILE=".jshintrc"
 
-	# Get path to jshintrc file
-	JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
-	if [[ ! -e "${JSHINT_CONFIG}" ]]
-	   then 
-	   JSHINT_CONFIG=${TM_JSHINT_CONFIG}
+	# Get path to jshintrc file if TM_JSHINT_CONFIG is not specified
+	if [[ -e "${TM_JSHINT_CONFIG}" ]]
+	then 
+		JSHINT_CONFIG=${TM_JSHINT_CONFIG}
+	else
+		JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
 	fi
 	
 	# Run linter and show the output in a textmate window

--- a/Commands/JSHint.tmCommand
+++ b/Commands/JSHint.tmCommand
@@ -8,25 +8,21 @@
 	<string>#!/usr/bin/env bash
 	[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
 
-	if [[ -e "$TM_DIRECTORY/.jshintrc" ]]
-	   then JSHINT_CONFIG="$TM_DIRECTORY/.jshintrc"
-	fi
+	# Command to execute to find config file
+	CONFIG_FINDER="${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh"
 
-	if [[ -e "$HOME/.jshintrc" ]]
-	   then JSHINT_CONFIG="$HOME/.jshintrc"
-	fi
+	# Name of the configuration file
+	JSHINT_RCFILE=".jshintrc"
 
-	if [[ -e "$TM_PROJECT_DIRECTORY/.jshintrc" ]]
-	   then JSHINT_CONFIG="$TM_PROJECT_DIRECTORY/.jshintrc"
+	# Get path to jshintrc file
+	JSHINT_CONFIG=`"${TM_BUNDLE_SUPPORT}/config-finder/config-finder.sh" -f "${JSHINT_RCFILE}" "${TM_FILEPATH}" "${HOME}" "${TM_DIRECTORY}"`
+	if [[ ! -e "${JSHINT_CONFIG}" ]]
+	   then 
+	   JSHINT_CONFIG=${TM_JSHINT_CONFIG}
 	fi
-
-	if [[ -e $TM_JSHINT_CONFIG ]]
-	   then JSHINT_CONFIG=$TM_JSHINT_CONFIG
-	fi
-
-	# run nodelint on the current file and output as a tool tip summary
+	
+	# Run linter and show the output in a textmate window
 	cd "${TM_BUNDLE_SUPPORT}/reporter/"
-
 	node index.js --reporter textmate-reporter.js --config "${JSHINT_CONFIG}" "${TM_FILEPATH}"
 
 	exit 0

--- a/README.md
+++ b/README.md
@@ -30,13 +30,12 @@ Originally forked from the [JSHint.tmbundle by oost](https://github.com/oost/JSH
 
 ### Configuration ###
 
-Bundle will look for the following places for JSHint configuration files:
+Bundle will use the .jshintrc location set in `${TM_JSHINT_CONFIG}`, or look for it in the following places:
 
- - default jshintrc provided with the bundle
+ - directory of currently opened file and all parent directories until one is found
  - `${HOME}/.jshintrc`
- - `${TM_PROJECT_DIRECTORY}/.jshintrc`
- - `${TM_JSHINT_CONFIG}`
-
+ - default jshintrc provided with the bundle
+ 
 ### Presentation ###
 
 By default, Textmate2 shows any bundle output in a popup window, but also supports a sidebar as shown in the screenshot above.

--- a/Support/config-finder/config-finder.sh
+++ b/Support/config-finder/config-finder.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Get file name from the -f param
+while getopts ":f:" opt; do
+	case "$opt" in
+		f) file=$OPTARG ;;
+	esac
+done
+shift $(( OPTIND - 1 ))
+
+# Usage information if no params were given
+if [[ "${file}" == "" || "${@}" == "" ]]
+then
+	echo "Usage: config-finder.sh -f filename paths..."
+	exit
+fi
+
+# Check all paths specified on command line
+for d in "$@";
+do
+	# Give it a name
+	dir=$d
+
+	# Make sure the directory exists
+	if [[ ! -e "${dir}" ]]
+	then
+		continue
+	fi
+
+	# Check if argument is a file or directory
+	if [[ -d "${dir}" ]]
+	then
+		cd "${dir}"
+	else
+		cd "`dirname \"${dir}\"`"
+	fi
+	path=$(pwd)
+
+	# Look for the specified file recursively in ancestor paths
+	while [[ "${path}" != "" && ! -e "${path}/${file}" ]]; do
+		path=${path%/*}
+	done
+
+	# If file was found echo to stdout
+	if [ "${path}" != "" ]
+	then
+		echo "${path}/${file}"
+		break
+	fi
+
+done


### PR DESCRIPTION
With this change the bundle will look for the first occurrence of a jshintrc file in the path structure starting from:
1. jshintrc file set in the TM_JSHINT_CONFIG env var
2. currently opened files location
3. users home directory
4. jshintrc shipped with the bundle

Fixes #4 
