### PR TITLE
Added display of the resolved config file name.

### DIFF
--- a/Support/reporter/config.js
+++ b/Support/reporter/config.js
@@ -1,0 +1,4 @@
+/**
+ * @file Options object shared between modules.
+ */
+module.exports = {};

--- a/Support/reporter/index.js
+++ b/Support/reporter/index.js
@@ -1,3 +1,20 @@
 var jshint = require('jshint/src/cli');
 
-jshint.interpret(process.argv);
+/*
+ * JSHint renderer does not receive the command line arguments that JSHint has received,
+ * so we parse out the options passed to JSHint to share them with the renderer.
+ */
+var config = require('./config');
+var args = [].concat(process.argv);
+for (var ic = args.length, i = 0; i < ic; ++i) {
+	if (args[i] === '--config') {
+		// Config file name follows the --config option:
+		config.configFile = args[i+1];
+	}
+	if (i === ic-1) {
+		// Target file comes the last:
+		config.targetFile = args[i];
+	}
+}
+
+jshint.interpret(args);

--- a/Support/reporter/textmate-reporter.js
+++ b/Support/reporter/textmate-reporter.js
@@ -4,7 +4,8 @@
 
 	var fs = require('fs'),
 		Handlebars = require('handlebars'),
-		JshintParser = require('./jshint-parser');
+		JshintParser = require('./jshint-parser'),
+		config = require('./config');
 
 	function render(errors, numErrors) {
 		var style = fs.readFileSync('./views/textmate-reporter.css', 'utf8'),
@@ -12,6 +13,7 @@
 			template = Handlebars.compile(content);
 
 		process.stdout.write(template({
+			config: config,
 			errors: errors,
 			numErrors: numErrors,
 			style: style

--- a/Support/reporter/views/textmate-reporter.css
+++ b/Support/reporter/views/textmate-reporter.css
@@ -19,7 +19,7 @@ header {
 	top: 0;
 	left: 0;
 	width: 100%;
-	height: 25px;
+	height: 50px;
 	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
 	font-size: 1.5em;
 	color: #fff;
@@ -29,10 +29,14 @@ header {
 	text-shadow: 0 -1px 1px #000;
 	white-space: nowrap;
 }
+header a {
+	color: #fff;
+	text-decoration: none;
+}
 header a.info {
 	position: absolute;
 	right: 30px;
-	top: 5px;
+	top: 3px;
 	display: block;
 	width: 13px;
 	height: 13px;
@@ -41,13 +45,21 @@ header a.info {
 	text-indent: -999em;
 	transition: background-color 0.1s linear, opacity 0.25s linear;
 }
+header .summary,
+header .additional {
+	position: relative;
+}
+header .additional {
+	margin-top: 5px;
+	font-size: 0.8em;
+}
 
 /* For single-window panel view */
 @media screen and (max-height: 350px) {}
 
 /*** Body ***/
 .problems {
-	margin: 35px 0px 0px 0px;
+	margin: 65px 0px 0px 0px;
 	padding: 0;
 	list-style: none;
 }

--- a/Support/reporter/views/textmate-reporter.html
+++ b/Support/reporter/views/textmate-reporter.html
@@ -17,12 +17,19 @@
 	</head>
 	<body onload="jump_to_first_problem();">
 		<header>
-			{{#if numErrors}}
+			<div class="summary">
+				<a class="problem" href="txmt://open?url=file://{{config.targetFile}}" title="Open target file">
+				{{#if numErrors}}
 				JSHint found {{numErrors}} problems
-			{{else}}
+				{{else}}
 				Lint-free!
-			{{/if}}
-			<a href="https://github.com/bodnaristvan/JSHint.tmbundle" class="info" title="About JSHint.tmbundle">info</a>
+				{{/if}}
+				</a>
+				<a href="https://github.com/bodnaristvan/JSHint.tmbundle" target="_blank" class="info" title="About JSHint.tmbundle">info</a>
+			</div>
+			<div class="additional">
+				<a href="txmt://open?url=file://{{config.configFile}}" title="Open config file">{{config.configFile}}</a>
+			</div>
 		</header>
 
 		{{#if numErrors}}
@@ -31,7 +38,7 @@
 					{{#each this}}
 						<li>
 							<a class="problem" href="txmt://open?url=file://{{file}}&line={{line}}&column={{column}}">
-								<span class="location">Line {{line}}</span>
+								<span class="location">Line {{line}}, column {{column}}</span>
 								<span class="desc">{{message}}</span>
 								<pre><code>{{evidence}}</code></pre>
 							</a>


### PR DESCRIPTION
When you have multiple .jshintrc files, you may get confused when linting reports or does not report certain errors. I've added the resolved config file name to the output header.

Also added display of column number (why not display it if we got it from JSHint?).
