### PR TITLE
Display jshint explanation articles inline

### DIFF
--- a/Support/reporter/jshint-parser.js
+++ b/Support/reporter/jshint-parser.js
@@ -25,6 +25,7 @@
 				memo[result.file].push({
 					file: result.file,
 					line: result.error.line,
+					code: result.error.code,
 					column: result.error.character,
 					message: result.error.reason,
 					evidence: (result.error.evidence || '').replace(/^\s\s*/, '').replace(/\s\s*$/, ''),

--- a/Support/reporter/views/textmate-reporter.css
+++ b/Support/reporter/views/textmate-reporter.css
@@ -85,6 +85,16 @@ header .additional {
 	padding: 0.5em;
 	text-decoration: none;
 }
+
+.problems .errorcode {
+	color: #000088;
+	font-size: 0.9em;
+	white-space: nowrap;
+	margin-left: 5px;
+	border-bottom: none;
+	float: right;
+}
+
 .problems .location {
 	float: right;
 	color: #b5372d;
@@ -124,6 +134,41 @@ header .additional {
 .problems a:active code {
 	background-color: #c0c0c0;
 	transition: none;
+}
+
+.errorinfo {
+	margin: 10px;
+	padding: 10px;
+	color: #666;
+	background-color: white;
+	border: 1px dotted black;
+}
+
+.errorinfo code {
+	background-color: #eee;
+	color: #449;
+}
+
+.errorinfo strong {
+	color: #555;
+}
+
+.errorinfo h3 {
+	color: #555;
+	text-decoration: underline;
+}
+
+.errorinfo a {
+	color: #55F;
+	text-decoration: underline;
+	border: 0;
+	padding: 0;
+	display: inline;
+}
+
+.errorinfo .errorinfo_header .sitelink {
+	float: right;
+	border: 0;
 }
 
 /*** Success check ***/

--- a/Support/reporter/views/textmate-reporter.css
+++ b/Support/reporter/views/textmate-reporter.css
@@ -95,6 +95,11 @@ header .additional {
 	float: right;
 }
 
+.problems .errorcode.apifail {
+	background-color: red;
+	color: white;
+}
+
 .problems .location {
 	float: right;
 	color: #b5372d;

--- a/Support/reporter/views/textmate-reporter.html
+++ b/Support/reporter/views/textmate-reporter.html
@@ -49,6 +49,9 @@
 									codelink.closest(".probrow").after(body);
 									$(".errorinfo a").attr("target", "_blank");
 								},
+								error: function() {
+									codelink.addClass("apifail");
+								},
 								dataType: 'json'
 							});
 						};

--- a/Support/reporter/views/textmate-reporter.html
+++ b/Support/reporter/views/textmate-reporter.html
@@ -2,7 +2,8 @@
 <html>
 	<head>
 		<meta charset="utf-8" />
-		<title>JSHint</title>
+		<title>JSHint</title> 
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 		<style>
 		{{{style}}}
 		</style>
@@ -13,6 +14,47 @@
 					return;
 				window.location = link.href;
 			}
+		</script>
+
+		<script type="text/javascript">
+			$(document).ready(function() {
+				$(document).on("click", "#close_errorinfo", function(e) {
+					$("div.errorinfo").remove();
+				});
+				
+				$("span.errorcode").on("click", function(e) {
+					// get code
+					var code = $(this).data("errorcode");
+						
+					if (code) {
+						if ($("div.errorinfo[data-errorcode="+code+"]").length >= 1) {
+							$("div.errorinfo").remove();
+						}
+						else
+						{
+							var codelink = $(this);
+							$("div.errorinfo").remove();
+							$.ajax({
+								url: "http://api.jslinterrors.com/explain",
+								data: { m: code, format: "html" },
+								success: function(data) {
+									var author = (data.author && data.author.name) ? data.author.name : ""; 
+									var sitelink = data.link; 
+									var body = '<div class="errorinfo" data-errorcode="' + code + '">' + 
+										'<div class="errorinfo_header">' + 
+											'<button id="close_errorinfo">Close Explanation</button>' + 
+											(data.link ? '<a class="sitelink" target="_blank" href="'+data.link+'">Article from  ' + (author ? author+" / " : "") + 'jslinterrors.com</a>' : '') + 
+										'</div>' + 
+										data.explanation + '</div>'
+									codelink.closest(".probrow").after(body);
+									$(".errorinfo a").attr("target", "_blank");
+								},
+								dataType: 'json'
+							});
+						};
+					}
+				});
+			});
 		</script>
 	</head>
 	<body onload="jump_to_first_problem();">
@@ -37,11 +79,14 @@
 				{{#each errors}}
 					{{#each this}}
 						<li>
-							<a class="problem" href="txmt://open?url=file://{{file}}&line={{line}}&column={{column}}">
-								<span class="location">Line {{line}}, column {{column}}</span>
-								<span class="desc">{{message}}</span>
-								<pre><code>{{evidence}}</code></pre>
-							</a>
+							<div class="probrow">
+								<a class="problem" href="txmt://open?url=file://{{file}}&line={{line}}&column={{column}}">
+									<span class="errorcode" data-errorcode="{{code}}">{{code}}</span>
+									<span class="location">(line {{line}}, col {{column}})</span>
+									<span class="desc">{{message}}</span>
+									<pre><code>{{evidence}}</code></pre>
+								</a>
+							</div>
 						</li>
 					{{/each}}
 				{{/each}}


### PR DESCRIPTION
Adds jshint warning codes to html output (useful for when trying to disable a specific warning using /\* jshint: -W089 */ etc)

Also hooks up to jslinterrors.com API, and when clicking the errorcode will display an inline article about the error. This is useful as the summary text from jshint can occasionally be cryptic.

![Sample Screenshot](http://i.imgur.com/hCU8xri.png)
