### PR TITLE
Bump JSHint version to 2.9.x

### DIFF
--- a/Support/reporter/package.json
+++ b/Support/reporter/package.json
@@ -3,7 +3,7 @@
 	"version":  "0.4.0",
 	"dependencies": {
 		"handlebars": "*",
-		"jshint": "2.5.*",
+		"jshint": "2.9.*",
 		"underscore": "1.5.x"
 	}
 }


### PR DESCRIPTION
This way, the plugin can support the [`esversion` flag](http://jshint.com/docs/options/#esversion).
